### PR TITLE
the test of whether ffinit/create_file would overwrite an existing fille was not win32 safe

### DIFF
--- a/t/create_file.t
+++ b/t/create_file.t
@@ -15,18 +15,18 @@ subtest 'ffopen' => sub {
 
 subtest 'create file' => sub {
 
-    my $fptr;
-
-    subtest 'ffinit' => sub {
-        ffinit( $fptr, '!testprog.fit', my $status = 0 );
-        is( $status, 0, 'status' );
-    };
-
     subtest 'create_file' => sub {
         my $fptr = Astro::FITS::CFITSIO::create_file( '!testprog.fit', my $status = 0 );
         is( $status, 0, 'status' );
         $fptr->delete_file( $status );
         is( $status, 252 );    # file is incomplete, so CFITSIO is unhappy
+    };
+
+    my $fptr;
+
+    subtest 'ffinit' => sub {
+        ffinit( $fptr, '!testprog.fit', my $status = 0 );
+        is( $status, 0, 'status' );
     };
 
     subtest 'ffflnm' => sub {


### PR DESCRIPTION
The test created a FITS handle to a new file, then attempted to delete/create the file while the first FITS handle (and thus the underlying file handle )was still active.

This is legal on *nix, but not on Windows:

   https://learn.microsoft.com/en-us/windows/win32/fileio/closing-and-deleting-files

   A file cannot be deleted until all handles to it are closed. If a file cannot be deleted, its name cannot be reused

The tests are reordered so that there are no open filehandles when the test for creating an existing file is done.